### PR TITLE
Add Android build GitHub workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,27 @@
+name: Android App Build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew assembleDebug --stacktrace


### PR DESCRIPTION
This commit introduces a new GitHub workflow for building the Android application. The workflow is triggered on pushes to the `master` branch and on pull requests targeting `master`. It sets up JDK 17, grants execute permission to `gradlew`, and then builds the app using Gradle with the `assembleDebug` task and `--stacktrace` option.